### PR TITLE
Fix issue parsing the Connection String when ApiKey is missing

### DIFF
--- a/src/Quartz.Impl.RavenDB/RavenJobStore.cs
+++ b/src/Quartz.Impl.RavenDB/RavenJobStore.cs
@@ -74,7 +74,7 @@ namespace Quartz.Impl.RavenDB
            
             Url = stringBuilder["Url"] as string;
             DefaultDatabase = stringBuilder["DefaultDatabase"] as string;
-            ApiKey = stringBuilder["ApiKey"] as string;
+            ApiKey = stringBuilder.ContainsKey("ApiKey") ? stringBuilder["ApiKey"] as string : null;
 
             InstanceName = "UnitTestScheduler";
             InstanceId = "instance_two";


### PR DESCRIPTION
Sorry I missed some basic testing.